### PR TITLE
Add RPM support

### DIFF
--- a/Redhat/.gitignore
+++ b/Redhat/.gitignore
@@ -1,0 +1,4 @@
+OpenTabletDriver/usr/share/OpenTabletDriver/
+OpenTabletDriver/usr/share/pixmaps/
+OpenTabletDriver/usr/lib/udev/rules.d/
+*.rpm

--- a/Redhat/OpenTabletDriver/LICENSE
+++ b/Redhat/OpenTabletDriver/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/Redhat/OpenTabletDriver/usr/bin/opentabletdriver
+++ b/Redhat/OpenTabletDriver/usr/bin/opentabletdriver
@@ -1,0 +1,10 @@
+#!/bin/bash
+systemctl --user --quiet is-active opentabletdriver
+daemonactive=$?
+
+if [ $daemonactive != 0 ]
+then
+  systemctl --user start opentabletdriver
+fi
+
+/usr/share/OpenTabletDriver/OpenTabletDriver.UX.Gtk "$@"

--- a/Redhat/OpenTabletDriver/usr/bin/otd
+++ b/Redhat/OpenTabletDriver/usr/bin/otd
@@ -1,0 +1,10 @@
+#!/bin/bash
+systemctl --user --quiet is-active opentabletdriver
+daemonactive=$?
+
+if [ $daemonactive != 0 ]
+then
+  systemctl --user start opentabletdriver
+fi
+
+/usr/share/OpenTabletDriver/OpenTabletDriver.Console "$@"

--- a/Redhat/OpenTabletDriver/usr/lib/systemd/user/opentabletdriver.service
+++ b/Redhat/OpenTabletDriver/usr/lib/systemd/user/opentabletdriver.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=OpenTabletDriver Daemon
+
+[Service]
+ExecStart=/usr/share/OpenTabletDriver/OpenTabletDriver.Daemon -c /usr/share/OpenTabletDriver/Configurations
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target

--- a/Redhat/OpenTabletDriver/usr/share/applications/OpenTabletDriver.desktop
+++ b/Redhat/OpenTabletDriver/usr/share/applications/OpenTabletDriver.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=0.0.0
+Name=OpenTabletDriver
+Exec=/usr/bin/opentabletdriver
+Icon=/usr/share/pixmaps/otd.png
+Terminal=false
+Type=Application
+StartupNotify=true
+Categories=Settings;

--- a/Redhat/opentabletdriver.spec
+++ b/Redhat/opentabletdriver.spec
@@ -1,0 +1,55 @@
+Name: opentabletdriver
+Version: 0.0.0
+Release: 1
+Summary: A cross-platform open source tablet driver
+BuildArch: x86_64
+
+%if 0%{?suse_version}
+License: LGPL-3.0-only
+Group: Hardware/Other
+%else
+License: LGPLv3
+%endif
+
+URL: https://github.com/OpenTabletDriver/OpenTabletDriver
+
+Requires: dotnet-runtime-5.0
+Requires: pkgconfig(libevdev)
+# Requires: pkgconfig(appindicator3-0.1) <- it is included in deb package but not in aur
+Requires: gtk3
+Recommends: pkgconfig(xrandr)
+Recommends: pkgconfig(x11)
+
+%description
+OpenTabletDriver is an open source, cross platform, user mode tablet driver. The goal of OpenTabletDriver is to be cross platform as possible with the highest compatibility in an easily configurable graphical user interface.
+
+%clean
+rm -f %{_builddir}/LICENSE
+
+%prep
+
+%build
+
+%install
+cp -r %{pkg_dir}/* %{buildroot}/
+rm %{buildroot}/LICENSE
+
+cp %{pkg_dir}/LICENSE %{_builddir}
+
+%post
+udevadm control --reload-rules
+
+%files
+%defattr(-,root,root)
+%license LICENSE
+%dir /usr/share/OpenTabletDriver
+/usr/share/OpenTabletDriver/*
+/usr/lib/udev/rules.d/99-opentabletdriver.rules
+/usr/share/pixmaps/otd.ico
+/usr/share/pixmaps/otd.png
+/usr/share/applications/OpenTabletDriver.desktop
+/usr/bin/opentabletdriver
+/usr/bin/otd
+/usr/lib/systemd/user/opentabletdriver.service
+
+%changelog

--- a/Redhat/package
+++ b/Redhat/package
@@ -29,8 +29,12 @@ clean() {
   clean_target "${PKG_RPM_FILE}" "Cleaning up existing builds..."
   clean_target "${OUT_DIR}" "Cleaning up build directory..."
   clean_target "${OUT_UDEV_FILE}" "Cleaning existing udev rules..."
-  clean_target "${OUT_DIR_PIXMAPS}" "Cleaning existing assets..."
-  rm -r BUILD BUILDROOT RPMS SOURCES SPECS SRPMS 2>/dev/null
+  clean_target "${SCRIPT_DIR}/BUILD" "Cleaning up BUILD folder..."
+  clean_target "${SCRIPT_DIR}/BUILDROOT" "Cleaning up BUILDROOT folder..."
+  clean_target "${SCRIPT_DIR}/RPMS" "Cleaning up RPMS folder..."
+  clean_target "${SCRIPT_DIR}/SOURCES" "Cleaning up SOURCES folder..."
+  clean_target "${SCRIPT_DIR}/SPECS" "Cleaning up SPECS folder..."
+  clean_target "${SCRIPT_DIR}/SRPMS" "Cleaning up SRPMS folder..."
 
   print "Cleaning 'opentabletdriver.spec'..."
   regex_edit "^Version: .\+$" "Version: 0.0.0" "${SPEC_FILE}"

--- a/Redhat/package
+++ b/Redhat/package
@@ -63,7 +63,7 @@ package() {
 
   update_version
 
-  create_rpmpkg "${PKG_DIR}" "${PKG_DEB_FILE}"
+  create_rpmpkg "${PKG_DIR}" "${PKG_RPM_FILE}"
 
   print "Packaging complete."
 }
@@ -92,8 +92,8 @@ create_rpmpkg() {
   [ "$#" -ne 2 ] && exit 104
   
   print "Packaging 'OpenTabletDriver.rpm'..."
-  rpmbuild -D "_topdir ${SCRIPT_DIR}" -D "pkg_dir ${PKG_DIR}" -bb ${SPEC_FILE}
-  mv ${SCRIPT_DIR}/RPMS/x86_64/opentabletdriver*.rpm ${PKG_RPM_FILE}
+  rpmbuild -D "_topdir ${SCRIPT_DIR}" -D "pkg_dir ${1}" -bb ${SPEC_FILE}
+  mv ${SCRIPT_DIR}/RPMS/x86_64/opentabletdriver*.rpm ${2}
 }
 
 case $1 in

--- a/Redhat/package
+++ b/Redhat/package
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+[ ! -d "${SCRIPT_DIR}" ] && exit 100;
+
+source "${SCRIPT_DIR}/../base"
+
+# Build arguments
+FRAMEWORK="net5"
+RUNTIME="linux-x64"
+PROJECTS=("OpenTabletDriver.Daemon" "OpenTabletDriver.Console" "OpenTabletDriver.UX.Gtk")
+
+# Directories
+PKG_DIR="${SCRIPT_DIR}/OpenTabletDriver"
+OUT_DIR="${PKG_DIR}/usr/share/OpenTabletDriver"
+OUT_DIR_CONFIGURATIONS="${OUT_DIR}/Configurations"
+OUT_DIR_PIXMAPS="${PKG_DIR}/usr/share/pixmaps"
+
+# Package
+PKG_RPM_FILE="${SCRIPT_DIR}/OpenTabletDriver.rpm"
+SPEC_FILE="${SCRIPT_DIR}/opentabletdriver.spec"
+
+# Files
+PKG_DESKTOP_FILE="${PKG_DIR}/usr/share/applications/OpenTabletDriver.desktop"
+OUT_UDEV_FILE="${PKG_DIR}/usr/lib/udev/rules.d/99-opentabletdriver.rules"
+
+# Output
+
+clean() {
+  clean_target "${PKG_RPM_FILE}" "Cleaning up existing builds..."
+  clean_target "${OUT_DIR}" "Cleaning up build directory..."
+  clean_target "${OUT_UDEV_FILE}" "Cleaning existing udev rules..."
+  clean_target "${OUT_DIR_PIXMAPS}" "Cleaning existing assets..."
+  rm -r BUILD BUILDROOT RPMS SOURCES SPECS SRPMS 2>/dev/null
+
+  print "Cleaning 'opentabletdriver.spec'..."
+  regex_edit "^Version: .\+$" "Version: 0.0.0" "${SPEC_FILE}"
+
+  print "Cleaning desktop file..."
+  regex_edit "^Version=.\+$" "Version=0.0.0" "${PKG_DESKTOP_FILE}"
+}
+
+build() {
+  print "Building OpenTabletDriver..."
+  for project in ${PROJECTS[@]}; do
+    dotnet publish "${SRC_DIR}/${project}"\
+      --runtime ${RUNTIME} \
+      --configuration Release \
+      --self-contained false \
+      --framework ${FRAMEWORK} \
+      --output ${OUT_DIR}
+  done
+}
+
+package() {
+  generate_rules "${SRC_DIR_CONFIGURATIONS}" "${OUT_UDEV_FILE}"
+
+  print "Copying all tablet configuration files to '${OUT_DIR_CONFIGURATIONS}'"
+  cp -vr "${SRC_DIR_CONFIGURATIONS}" "${OUT_DIR_CONFIGURATIONS}"
+
+  copy_assets "${OUT_DIR_PIXMAPS}"
+
+  clean_debug "${OUT_DIR}"
+
+  update_version
+
+  create_rpmpkg "${PKG_DIR}" "${PKG_DEB_FILE}"
+
+  print "Packaging complete."
+}
+
+copy_assets() {
+  [ "$#" -ne 1 ] && exit 102
+  ASSET_DIR="${SRC_DIR}/OpenTabletDriver.UX/Assets"
+  [ ! -d "${ASSET_DIR}" ] && exit 103
+
+  print "Copying assets to '${1}'..."
+  mkdir -p "${1}"
+  cp -v ${ASSET_DIR}/* "${1}"
+}
+
+update_version() {
+  PKG_VERSION=$(get_group "$(cat ${SRC_DIR}/OpenTabletDriver/OpenTabletDriver.csproj)" '<VersionPrefix>(.+?)<\/VersionPrefix>' 1)
+
+  print "Updating version in opentabletdriver.spec"
+  regex_edit "Version: .\+$" "Version: ${PKG_VERSION}" "${SPEC_FILE}"
+
+  print "Updating version in desktop file"
+  regex_edit "Version=.\+$" "Version=${PKG_VERSION}" "${PKG_DESKTOP_FILE}"
+}
+
+create_rpmpkg() {
+  [ "$#" -ne 2 ] && exit 104
+  
+  print "Packaging 'OpenTabletDriver.rpm'..."
+  rpmbuild -D "_topdir ${SCRIPT_DIR}" -D "pkg_dir ${PKG_DIR}" -bb ${SPEC_FILE}
+  mv ${SCRIPT_DIR}/RPMS/x86_64/opentabletdriver*.rpm ${PKG_RPM_FILE}
+}
+
+case $1 in
+    "clean") clean ;;
+    "prepare") prepare ;;
+    "build") build ;;
+    "package") package ;;
+    *)
+        clean
+        prepare
+        build
+        package
+    ;;
+esac


### PR DESCRIPTION
Basically, I re-used a debian packaging script and directory structure, but I made changes here and there, so they are not really compatible each other.

This PR requires `rpmbuild` to build RPM from a spec file.
It produces some useless folders like SRPMS and SOURCES, but I haven't found any workarounds for this so it will just remove these folders in clean()

I tested it on openSUSE Leap 15.3 and it is working fine for me, but I haven't tested on Fedora yet
