### PR TITLE
Add modprobe files for Debian/Redhat and edit post-install scripts

### DIFF
--- a/Debian/OpenTabletDriver/DEBIAN/postinst
+++ b/Debian/OpenTabletDriver/DEBIAN/postinst
@@ -1,3 +1,8 @@
 udevadm control --reload-rules
-((lsmod | grep hid_uclogic > /dev/null) && rmmod hid_uclogic) || true
-((lsmod | grep wacom > /dev/null) && rmmod wacom) || true
+if lsmod | grep hid_uclogic > /dev/null ; then
+     rmmod hid_uclogic || true
+fi
+
+if lsmod | grep wacom > /dev/null ; then
+     rmmod wacom || true
+fi

--- a/Debian/OpenTabletDriver/DEBIAN/postinst
+++ b/Debian/OpenTabletDriver/DEBIAN/postinst
@@ -1,1 +1,3 @@
 udevadm control --reload-rules
+((lsmod | grep hid_uclogic > /dev/null) && rmmod hid_uclogic) || true
+((lsmod | grep wacom > /dev/null) && rmmod wacom) || true

--- a/Debian/OpenTabletDriver/usr/lib/modprobe.d/99-opentabletdriver.conf
+++ b/Debian/OpenTabletDriver/usr/lib/modprobe.d/99-opentabletdriver.conf
@@ -1,0 +1,2 @@
+blacklist hid_uclogic
+blacklist wacom

--- a/Redhat/OpenTabletDriver/usr/lib/modprobe.d/99-opentabletdriver.conf
+++ b/Redhat/OpenTabletDriver/usr/lib/modprobe.d/99-opentabletdriver.conf
@@ -1,0 +1,2 @@
+blacklist hid_uclogic
+blacklist wacom

--- a/Redhat/opentabletdriver.spec
+++ b/Redhat/opentabletdriver.spec
@@ -39,8 +39,14 @@ cp %{pkg_dir}/LICENSE %{_builddir}
 
 %post
 udevadm control --reload-rules
-((lsmod | grep hid_uclogic > /dev/null) && rmmod hid_uclogic) || true
-((lsmod | grep wacom > /dev/null) && rmmod wacom) || true
+
+if lsmod | grep hid_uclogic > /dev/null ; then
+     rmmod hid_uclogic || true
+fi
+
+if lsmod | grep wacom > /dev/null ; then
+     rmmod wacom || true
+fi
 
 %files
 %defattr(-,root,root)

--- a/Redhat/opentabletdriver.spec
+++ b/Redhat/opentabletdriver.spec
@@ -31,6 +31,7 @@ rm -f %{_builddir}/LICENSE
 %build
 
 %install
+mkdir -p %{buildroot}
 cp -r %{pkg_dir}/* %{buildroot}/
 rm %{buildroot}/LICENSE
 
@@ -38,6 +39,8 @@ cp %{pkg_dir}/LICENSE %{_builddir}
 
 %post
 udevadm control --reload-rules
+((lsmod | grep hid_uclogic > /dev/null) && rmmod hid_uclogic) || true
+((lsmod | grep wacom > /dev/null) && rmmod wacom) || true
 
 %files
 %defattr(-,root,root)
@@ -45,6 +48,7 @@ udevadm control --reload-rules
 %dir /usr/share/OpenTabletDriver
 /usr/share/OpenTabletDriver/*
 /usr/lib/udev/rules.d/99-opentabletdriver.rules
+/usr/lib/modprobe.d/99-opentabletdriver.conf
 /usr/share/pixmaps/otd.ico
 /usr/share/pixmaps/otd.png
 /usr/share/applications/OpenTabletDriver.desktop


### PR DESCRIPTION
This PR enables DEB/RPM packages to disable hid_uclogic and wacom right after installation, and put a modprobe configuration file in `/usr/lib/modprobe.d` to disable them permanently.