### PR TITLE
Update control

### DIFF
--- a/Debian/OpenTabletDriver/DEBIAN/control
+++ b/Debian/OpenTabletDriver/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 0.0.0
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: libevdev-dev, libgtk-3-0, libappindicator3-dev, dotnet-runtime-5.0
+Depends: libevdev-dev, libgtk-3-0, libayatana-appindicator-dev, dotnet-runtime-5.0
 Recommends: libx11-dev, libxrandr-dev
 Installed-Size: 0
 Maintainer: InfinityGhost <infinityghostgit@gmail.com>


### PR DESCRIPTION
Changed the dependencies slightly so that Debian 11 (Buster) can run the file, as libappindicator is now deprecated.