### PR TITLE
systemd services: Remove hardcoded configurations path

### DIFF
--- a/Debian/OpenTabletDriver/usr/lib/systemd/user/opentabletdriver.service
+++ b/Debian/OpenTabletDriver/usr/lib/systemd/user/opentabletdriver.service
@@ -2,7 +2,7 @@
 Description=OpenTabletDriver Daemon
 
 [Service]
-ExecStart=/usr/share/OpenTabletDriver/OpenTabletDriver.Daemon -c /usr/share/OpenTabletDriver/Configurations
+ExecStart=/usr/share/OpenTabletDriver/OpenTabletDriver.Daemon
 Restart=always
 RestartSec=30
 

--- a/Redhat/OpenTabletDriver/usr/lib/systemd/user/opentabletdriver.service
+++ b/Redhat/OpenTabletDriver/usr/lib/systemd/user/opentabletdriver.service
@@ -2,7 +2,7 @@
 Description=OpenTabletDriver Daemon
 
 [Service]
-ExecStart=/usr/share/OpenTabletDriver/OpenTabletDriver.Daemon -c /usr/share/OpenTabletDriver/Configurations
+ExecStart=/usr/share/OpenTabletDriver/OpenTabletDriver.Daemon
 Restart=always
 RestartSec=30
 


### PR DESCRIPTION
Configurations have been compiled in for quite a while, leaving this relic of the past decidedly unwanted as it is preventing users from using a local configuration override (which slows down making new configurations)

I've already applied the appropriate change to the Arch package [as seen here](https://aur.archlinux.org/cgit/aur.git/commit/?h=opentabletdriver&id=c05d183e5f05bf08ab2af9da7e0d60a7f88c2dab).

related discord convo: https://discord.com/channels/615607687467761684/628651971267788800/1039986116490711081
