### PR TITLE
Fix RPM Mono dependencies and remove systemd presets

### DIFF
--- a/Redhat/OpenTabletDriver/usr/lib/systemd/user-preset/50-opentabletdriver.preset
+++ b/Redhat/OpenTabletDriver/usr/lib/systemd/user-preset/50-opentabletdriver.preset
@@ -1,1 +1,0 @@
-enable opentabletdriver.service

--- a/Redhat/opentabletdriver.spec
+++ b/Redhat/opentabletdriver.spec
@@ -1,15 +1,14 @@
+# We don't have debug symbols, because .NET
+%define debug_package %{nil}
+# We aren't using Mono but RPM expected Mono
+%global __requires_exclude_from ^/usr/share/OpenTabletDriver/.*$
+
 Name: opentabletdriver
 Version: 0.0.0
 Release: 1
 Summary: A cross-platform open source tablet driver
-BuildArch: x86_64
-
-%if 0%{?suse_version}
-License: LGPL-3.0-only
-Group: Hardware/Other
-%else
 License: LGPLv3
-%endif
+BuildArch: x86_64
 
 URL: https://github.com/OpenTabletDriver/OpenTabletDriver
 
@@ -36,11 +35,8 @@ rm %{buildroot}/LICENSE
 
 cp %{pkg_dir}/LICENSE %{_builddir}
 
-%pre
-
 %post
 udevadm control --reload-rules
-%systemd_user_post opentabletdriver.service
 
 if lsmod | grep hid_uclogic > /dev/null ; then
      rmmod hid_uclogic || true
@@ -49,12 +45,6 @@ fi
 if lsmod | grep wacom > /dev/null ; then
      rmmod wacom || true
 fi
-
-%preun
-%systemd_user_preun opentabletdriver.service
-
-%postun
-%systemd_user_postun opentabletdriver.service
 
 %files
 %defattr(-,root,root)
@@ -69,6 +59,3 @@ fi
 /usr/bin/opentabletdriver
 /usr/bin/otd
 /usr/lib/systemd/user/opentabletdriver.service
-/usr/lib/systemd/user-preset/50-opentabletdriver.preset
-
-%changelog


### PR DESCRIPTION
This PR removes Mono dependencies (thanks to @korewaChino for providing a fix ~~our pr didn't make it to the end~~) and also removes systemd presets since it doesn't work reliably

Small version of #16 because our main developer didn't like the script, and I also thought it'd be better to keep the _proper_ method to myself since making such big changes that the actual maintainer doesn't understand will eventually be a burden of both me and him